### PR TITLE
Display event summary instead of empty alarm description

### DIFF
--- a/remhind/events.py
+++ b/remhind/events.py
@@ -323,6 +323,10 @@ class EventCollection:
                     self.db.add_alarm(
                         cal_obj['uid'], alarm_dt, dt, message, is_todo,
                         sequence)
+                elif summary:
+                    self.db.add_alarm(
+                        cal_obj['uid'], alarm_dt, dt, summary, is_todo,
+                        sequence)
 
             if summary:
                 self.db.add_alarm(


### PR DESCRIPTION
```
-%<-
DTSTART;TZID=Europe/Paris;VALUE=DATE-TIME:20200128T180000
DTEND;TZID=Europe/Paris;VALUE=DATE-TIME:20200128T190000
-%<-
BEGIN:VALARM
ACTION:DISPLAY
DESCRIPTION:
TRIGGER:-PT16M
-%<-
```

=> Alarm to "2020-01-28 17:44" but it was to "2020-01-28 18:00"

The relative trigger was used to compute the alarm_dt date.
Unfortunately, we used this value only if there was a value as
description.

If not, we used the dt date value and forget the computed trigger date.