### PR TITLE
Display passed alarms for futures events

### DIFF
--- a/remhind/events.py
+++ b/remhind/events.py
@@ -179,7 +179,7 @@ class SQLiteDB:
         cursor.execute("""
             SELECT id, event, message, date, due_date
             FROM alarms
-            WHERE (date >= ?) AND (date < ?) AND (vtodo = 0)
+            WHERE (due_date >= ?) AND (date < ?) AND (vtodo = 0)
             """, (start, end))
         return [Alarm(*r) for r in cursor.fetchall()]
 


### PR DESCRIPTION
Admit my vdirsyncer instance just fetched an ics event from a futur
event in 1 hour, and a passed alarm from 1 hour.
Due to the fact this alarm has not been done, we want it to be displayed.

This fix got performance optimization consequences. Maybe we could
daemonize remhind on minutes instead of 45s?