### PR TITLE
Configurable automatic alerts, notification template

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,37 @@ Those directories will be monitored for change in order to allow you to use
 solution like [vdirsyncer](https://github.com/pimutils/vdirsyncer) to sync your
 CalDAV server with your local filesystem.
 
+## Installing
+
+`remhind` can be installed through PyPI using pip.
+
+```sh
+pip install remhind
+```
+
 ## Getting Started
 
 `remhind` use a [toml](https://github.com/toml-lang/toml) configuration file
 indicating which directories holds your event files. Here's a simple example:
 
+```toml
+[calendars]
+    [calendars.test]
+    name = "Test"
+    path = "~/projets/perso/remhind/test_calendar"
 ```
+
+### Default alerts
+
+`remhind` displays notification for calendar events even if they don't have an
+alert set. By deafult his happens at the time the event starts but can
+be configured in the configuration file as in the following example.  
+Note that the default is `[ 0 ]` and you have to include `0` in your
+configuration if you want an alert at the time of the event.
+
+```toml
+[notifications]
+    alert_before_event_minutes = [ 15, 5, 0 ]
 [calendars]
     [calendars.test]
     name = "Test"
@@ -29,7 +54,7 @@ values are
 - 5000 - A number will be interpreted as timeout in milliseconds. The
     notification will automatically disappear after this time.
 
-```
+```toml
 [notifications]
     timeout = "NEVER"
 [calendars]
@@ -38,12 +63,31 @@ values are
     path = "~/projets/perso/remhind/test_calendar"
 ```
 
-## Installing
+### Notification templates
 
-`remhind` can be installed through PyPI using pip.
+If you are not satisfied with the look of the default notifications you can
+style them yourself. The template engine is [jinja2](https://jinja.palletsprojects.com/)
+and the template files used can be specied with the `--title-template` and
+`--message-template` argument.  
+They default to `~/.config/remhind/title.j2` and `~/config/remhind/message.j2`
 
+- `alarm`: alarm,
+- `in_time`: "in X days Y hours Z minutes" - a human readable version of difference,
+- `difference`: shorthand for alarm.due_date - alarm.date
+- `now`: datetime.now()
+
+If no template file is given the following templates will be used
+
+title
+
+```jinja2
+{{ alarm.due_date.hour }}:{{ alarm.due_date.minute }} {{alarm.message}}
 ```
-pip install remhind
+
+message
+
+```jinja2
+Alarm
 ```
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ If no template file is present the following default templates will be used
 Alarm
 ```
 
+### Override alert message
+
+You can specify a list of alert messages which you want replaced by the events
+summary. Not that the message is converted to upper case before being checked
+make sure to write your entries in all upper case.
+
+This is useful for example when using `khal`. `khal` sets reminders without a
+specific message to have the message `None`. The following example will display
+those `khal` reminders with the event summary instead.
+
+```toml
+[notifications]
+    override_alert_message = [ "NONE" ]
+```
+
 ## Acknowledgments
 
 This work has been inspired by the work of the [pimutils group](https://github.com/pimutils)

--- a/README.md
+++ b/README.md
@@ -71,20 +71,20 @@ and the template files used can be specied with the `--title-template` and
 `--message-template` argument.  
 They default to `~/.config/remhind/title.j2` and `~/config/remhind/message.j2`
 
-- `alarm`: alarm,
+- `alarm`: alarm `{id,message,event,date,due_date}`,
 - `in_time`: "in X days Y hours Z minutes" - a human readable version of difference,
 - `difference`: shorthand for alarm.due_date - alarm.date
 - `now`: datetime.now()
 
-If no template file is given the following templates will be used
+If no template file is present the following default templates will be used
 
-title
+#### title
 
 ```jinja2
 {{ alarm.due_date.hour }}:{{ alarm.due_date.minute }} {{alarm.message}}
 ```
 
-message
+#### message
 
 ```jinja2
 Alarm

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ style them yourself. The template engine is [jinja2](https://jinja.palletsprojec
 and the template files used can be specified with the `--title-template` and
 `--message-template` argument.  
 They default to `~/.config/remhind/title.j2` and `~/.config/remhind/message.j2`.
-`.config` standing for your xdg home directory
+`.config` standing for your xdg config directory
 
 - `alarm`: alarm `{id,message,event,date,due_date}`,
 - `in_time`: "in X days Y hours Z minutes" - a human readable version of difference,

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ If you are not satisfied with the look of the default notifications you can
 style them yourself. The template engine is [jinja2](https://jinja.palletsprojects.com/)
 and the template files used can be specified with the `--title-template` and
 `--message-template` argument.  
-They default to `~/.config/remhind/title.j2` and `~/config/remhind/message.j2`
+They default to `~/.config/remhind/title.j2` and `~/.config/remhind/message.j2`.
+`.config` standing for your xdg home directory
 
 - `alarm`: alarm `{id,message,event,date,due_date}`,
 - `in_time`: "in X days Y hours Z minutes" - a human readable version of difference,

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ indicating which directories holds your event files. Here's a simple example:
 ### Default alerts
 
 `remhind` displays notification for calendar events even if they don't have an
-alert set. By deafult his happens at the time the event starts but can
+alert set. By default his happens at the time the event starts but can
 be configured in the configuration file as in the following example.  
 Note that the default is `[ 0 ]` and you have to include `0` in your
 configuration if you want an alert at the time of the event.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ indicating which directories holds your event files. Here's a simple example:
     path = "~/projets/perso/remhind/test_calendar"
 ```
 
+### Notification timeout
+
+You can can specify a timeout for your notifications in the config file. Allowed
+values are
+
+- DEFAULT or NOT SET - Use your notification tools' default timeout
+- NEVER - Notification will be displayed until clicked away
+- 5000 - A number will be interpreted as timeout in milliseconds. The
+    notification will automatically disappear after this time.
+
+```
+[notifications]
+    timeout = "NEVER"
+[calendars]
+    [calendars.test]
+    name = "Test"
+    path = "~/projets/perso/remhind/test_calendar"
+```
+
 ## Installing
 
 `remhind` can be installed through PyPI using pip.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ and the template files used can be specied with the `--title-template` and
 They default to `~/.config/remhind/title.j2` and `~/config/remhind/message.j2`
 
 - `alarm`: alarm,
-- `in_time`: "in X days Y hours Z minutes" - a human readable version of difference,
-- `difference`: shorthand for alarm.due_date - alarm.date
+- `in_time`: "in X days Y hours Z minutes" - a human readable version of
+    time_until_alert,
+- `time_until_alert`: shorthand for alarm.due_date - alarm.date
 - `now`: datetime.now()
 
 If no template file is given the following templates will be used

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ indicating which directories holds your event files. Here's a simple example:
 You can can specify a timeout for your notifications in the config file. Allowed
 values are
 
-- DEFAULT or NOT SET - Use your notification tools' default timeout
-- NEVER - Notification will be displayed until clicked away
+- `DEFAULT` - Use your notification tools' default timeout. This is the same as
+    not setting any option
+- `NEVER` - Notification will be displayed until clicked away
 - 5000 - A number will be interpreted as timeout in milliseconds. The
     notification will automatically disappear after this time.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ values are
 
 If you are not satisfied with the look of the default notifications you can
 style them yourself. The template engine is [jinja2](https://jinja.palletsprojects.com/)
-and the template files used can be specied with the `--title-template` and
+and the template files used can be specified with the `--title-template` and
 `--message-template` argument.  
 They default to `~/.config/remhind/title.j2` and `~/config/remhind/message.j2`
 

--- a/remhind/__main__.py
+++ b/remhind/__main__.py
@@ -31,7 +31,7 @@ async def monitor_file_events(args):
     notifier = Notifier(notifications_config, args.title_template, args.message_template)
 
     if args.action == "test":
-        display_test_event(notifier)
+        display_test_event(notifier, args.in_minutes)
         return
 
     calendars = CalendarStore(config['calendars'].values(), args.database,
@@ -57,6 +57,7 @@ def main():
     parser.add_argument('-d', '--database', type=pathlib.Path,
         default=XDG_CACHE_HOME / 'remhind.db')
     parser.add_argument('-v', '--verbose', action='count', default=0)
+    parser.add_argument('--in-minutes', default=5)
 
     asyncio.run(monitor_file_events(parser.parse_args()))
 

--- a/remhind/__main__.py
+++ b/remhind/__main__.py
@@ -25,7 +25,12 @@ async def monitor_file_events(args):
 
     calendars = CalendarStore(config['calendars'].values(), args.database)
 
-    events_checker = check_events(config['notifications'], calendars)
+    try:
+        notifications_config = config['notifications']
+    except KeyError:
+        notifications_config = {}
+
+    events_checker = check_events(notifications_config, calendars)
     calendars_monitor = monitor_calendars(config['calendars'], calendars)
     await asyncio.gather(events_checker, calendars_monitor)
 

--- a/remhind/__main__.py
+++ b/remhind/__main__.py
@@ -25,7 +25,7 @@ async def monitor_file_events(args):
 
     calendars = CalendarStore(config['calendars'].values(), args.database)
 
-    events_checker = check_events(calendars)
+    events_checker = check_events(config['notifications'], calendars)
     calendars_monitor = monitor_calendars(config['calendars'], calendars)
     await asyncio.gather(events_checker, calendars_monitor)
 

--- a/remhind/events.py
+++ b/remhind/events.py
@@ -102,13 +102,14 @@ class Alarm:
     due_date: Optional[dt.datetime] = None
 
     @staticmethod
-    def get_example_alarm():
+    def get_example_alarm(in_minutes=5):
         return Alarm(
             id=4522,
             event='58J8X5N2ZGVEGU5TUWURLZKGQIAQQRQ73GVN',
             message='I have a date',
             date_timestamp = _to_utc_timestamp(dt.datetime.now()),
-            due_timestamp = _to_utc_timestamp(dt.datetime.now() + dt.timedelta(minutes=5))
+            due_timestamp = _to_utc_timestamp(dt.datetime.now() +
+                                              dt.timedelta(minutes=int(in_minutes)))
         )
 
     def __post_init__(self, date_timestamp, due_timestamp):
@@ -427,9 +428,9 @@ class CalendarStore:
         for cal_file, component in self._get_components_from_ics(ics):
             self.events.add(component, cal_file)
 
-def display_test_event(notifier):
+def display_test_event(notifier, in_minutes):
     logging.info(f'Displaying test event')
-    event = Alarm.get_example_alarm()
+    event = Alarm.get_example_alarm(in_minutes)
     notifier.show(event)
     logging.debug(f'test event displayed')
 

--- a/remhind/events.py
+++ b/remhind/events.py
@@ -430,19 +430,21 @@ async def check_events(notification_config, calendar_store):
         await asyncio.sleep(45)
 
 def add_notification_timeout(notification_config, notification):
-    timeout = Notify.EXPIRES_DEFAULT
     try:
-        timeout = notification_config['timeout']
-        if timeout == "NEVER":
-            timeout = Notify.EXPIRES_NEVER
-            logging.debug(
-                f'notification timeout: never')
-        else:
-            timeout = int(timeout)
-            logging.debug(
-                f'notification timeout: '+str(timeout))
-    except ValueError:
-        logging.debug(f'notification timeout: default')
-        pass
+        config_timeout = notification_config['timeout']
+    except KeyError:
+        logging.debug(f'Using default timeout')
+        return
+        
+    if config_timeout == "DEFAULT":
+        logging.debug(f'Using default timeout')
+        return;
 
+    if config_timeout == "NEVER":
+        logging.debug(f'Timeout: never')
+        notification.set_timeout(Notify.EXPIRES_NEVER)
+        return
+
+    timeout = int(config_timeout);
+    logging.debug(f'Timeout in milliseconds: '+str(timeout) )
     notification.set_timeout(timeout)

--- a/remhind/events.py
+++ b/remhind/events.py
@@ -328,7 +328,11 @@ class EventCollection:
                         alarm_dt = event_dt + trigger.dt
 
                 message = component.get('description', summary)
-                if message.upper() == 'NONE':
+                try:
+                   override_alert_message = self._config['override_alert_message']
+                except KeyError:
+                    override_alert_message = []
+                if message.upper() in override_alert_message:
                     message = summary
                 if message:
                     self.db.add_alarm(

--- a/remhind/events.py
+++ b/remhind/events.py
@@ -11,7 +11,7 @@ import gi
 import icalendar
 import pytz
 from dateutil.rrule import rruleset, rrulestr
-from tzlocal import get_localzone
+from tzlocal import get_localzone 
 
 LOCAL_TZ = get_localzone()
 MIN_SEQ = -999
@@ -53,10 +53,16 @@ def parse_rule(component):
     rrules = component.get('rrule', [])
     if not isinstance(rrules, list):
         rrules = [rrules]
+
+    tz = str(dtstart.tzinfo)
+    isotime = dtstart.isoformat()
+    time = isotime[:isotime.rfind('+')]
     for rrule in rrules:
-        rule_set.rrule(rrulestr(
-                'RRULE:%s' % rrule.to_ical().decode(),
-                dtstart=dtstart))
+        rule = """
+        DTSTART;TZID=%s:%s
+        RRULE:%s
+        """ % (tz, time, rrule.to_ical().decode())
+        rule_set.rrule(rrulestr(rule))
 
     rdates = component.get('rdate', [])
     if not isinstance(rdates, list):
@@ -69,9 +75,10 @@ def parse_rule(component):
     if not isinstance(exrules, list):
         exrules = [exrules]
     for exrule in exrules:
-        rule_set.exrule(rrulestr(
-                'EXRULE:%s' % exrule.to_ical().decode(),
-                dtstart=dtstart))
+        rule = """
+        DTSTART;TZID=%s:%s
+        EXRULE:%s
+        """ % (tz, time, exrule.to_ical().decode())
 
     exdates = component.get('exdate', [])
     if not isinstance(exdates, list):

--- a/remhind/notification.py
+++ b/remhind/notification.py
@@ -1,0 +1,111 @@
+import datetime as dt
+
+import gi
+import logging
+from jinja2 import Template
+
+gi.require_version('Notify', '0.7')
+from gi.repository import Notify  # noqa
+
+class Notifier:
+    def __init__(self, config=None, title_template_path=None, message_template_path=None):
+        self._config = config
+        self._title_template_path = title_template_path
+        self._message_template_path = message_template_path
+
+        self._load_title_template(title_template_path)
+        self._load_message_template(message_template_path)
+
+    def _load_title_template(self, template_path):
+        template_content = self._load_template(template_path, "{{ alarm.due_date.hour }}:{{ alarm.due_date.minute }} {{alarm.message}}")
+        self._title_template = Template(template_content)
+
+    def _load_message_template(self, template_path):
+        template_content = self._load_template(template_path, 'Alarm')
+        self._message_template = Template(template_content)
+
+    def _load_template(self, template_path, default):
+        try:
+            with open(template_path, 'r') as myfile:
+                template_content = myfile.read()
+        except OSError:
+            logging.debug(
+                f'Template not found at '+str(template_path)+f' - using default template')
+            return default
+        return template_content
+
+    def show(self, alarm):
+        logging.debug(
+            f'Notifying of alarm {alarm.id} "{alarm.message}"'+str(alarm))
+        title, message = self._format_alarm(alarm)
+        n = Notify.Notification.new(title, message)
+        self._add_notification_timeout(n)
+        n.show()
+
+    def _format_alarm(self, alarm):
+        difference = alarm.due_date - alarm.date
+        context = {
+            "alarm": alarm,
+            "in_time": self._format_time_difference(difference),
+            "difference": difference,
+            "now": dt.datetime.now()
+        }
+
+        title = self._format_title(context)
+        message = self._format_message(context)
+
+        return [ title, message ]
+
+    def _format_title(self, context):
+        return self._title_template.render(context)
+
+    def _format_message(self, context):
+        return self._message_template.render(context)
+
+    def _format_time_difference(self, difference):
+        if difference < dt.timedelta(minutes=1):
+            return ""
+
+        days, remainder = divmod(difference.seconds, 86400)
+        hours, remainder = divmod(remainder, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        if seconds > 30:
+            minutes += 1
+
+        in_time = [ 'in' ]
+        self._pluralize_if_not_zero(in_time, days, 'days')
+        self._pluralize_if_not_zero(in_time, hours, 'hours')
+        self._pluralize_if_not_zero(in_time, minutes, 'minutes')
+        return " ".join(in_time)
+
+    def _pluralize_if_not_zero(self, in_time, number, unit):
+        if number == 0:
+            return
+        result = self._pluralize(in_time, number, unit)
+        in_time.append(result)
+
+    def _pluralize(self, in_time, number, unit):
+        result = str(number)+" "+unit
+        if abs(number) > 1:
+            result += 's'
+        return result
+
+    def _add_notification_timeout(self, notification):
+        try:
+            config_timeout = self._config['timeout']
+        except KeyError:
+            logging.debug(f'Using default timeout')
+            return
+
+        if config_timeout == "DEFAULT":
+            logging.debug(f'Using default timeout')
+            return
+
+        if config_timeout == "NEVER":
+            logging.debug(f'Timeout: never')
+            notification.set_timeout(Notify.EXPIRES_NEVER)
+            return
+
+        timeout = int(config_timeout)
+        logging.debug(f'Timeout in milliseconds: '+str(timeout) )
+        notification.set_timeout(timeout)

--- a/remhind/notification.py
+++ b/remhind/notification.py
@@ -73,9 +73,9 @@ class Notifier:
             minutes += 1
 
         in_time = [ 'in' ]
-        self._pluralize_if_not_zero(in_time, days, 'days')
-        self._pluralize_if_not_zero(in_time, hours, 'hours')
-        self._pluralize_if_not_zero(in_time, minutes, 'minutes')
+        self._pluralize_if_not_zero(in_time, days, 'day')
+        self._pluralize_if_not_zero(in_time, hours, 'hour')
+        self._pluralize_if_not_zero(in_time, minutes, 'minute')
         return " ".join(in_time)
 
     def _pluralize_if_not_zero(self, in_time, number, unit):

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install-requires =
     toml
     tzlocal
     xdg
+    jinja2
 test-require =
     freezegun
 


### PR DESCRIPTION
Okay this is a bit of a big one

I found the code really easy to work with in the set notification timeout pull request so I simply added all the features I wanted for myself. And I thought maybe someone else out there would want them too

## alert_before_event_minutes
Replaces the static alert at the time of an event. An array with each entry standing for a time in minutes before(or after, if negative) the event where an alarm should be fired. Defaults to `[ 0 ]` which keeps the previous behaviour of sending a notification when the event starts.

## notification templates
I wanted to change my notifications because the static "Alarm" message seemed out of place and useless to me. Instead of making a static change I eventually decided to use the jinja2 engine to style the title and message and leave it up to each user how their own alerts should look
The template files for both title and message can be set via command line but default to `~/.config/remhind/{title,message}.j2`. If they are not present then the following defaults will be used

- title: `{{ alarm.due_date.hour }}:{{ alarm.due_date.minute }} {{alarm.message}}`
- message: `Alarm`

which should be the same as the current static behaviour

## test action
You can now start remhind with `remhind test` to display a test alert - useful to try out your notification templates

## Replace `None` alert messages with event summary
khal sets notification messages to `None` for alerts without a specified error message. I added a static check for this to replace `None` with the event summary. I might improve this by letting a user set a list of alert messages which should be replaced.